### PR TITLE
Add workflow to comment Nagare test SVG on PRs

### DIFF
--- a/.github/workflows/render-preview.yml
+++ b/.github/workflows/render-preview.yml
@@ -1,0 +1,77 @@
+name: Render diagram preview
+
+on:
+  pull_request:
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+          cache: true
+          cache-dependency-path: |
+            nagare/go.mod
+            nagare/go.sum
+
+      - name: Download dependencies
+        working-directory: nagare
+        run: go mod download
+
+      - name: Start Nagare server
+        run: |
+          cd nagare
+          go run ./cmd/nagare/main.go > server.log 2>&1 &
+          echo $! > server.pid
+
+      - name: Fetch /test SVG output
+        run: |
+          for attempt in {1..20}; do
+            if curl -fsS http://localhost:8080/test -o nagare-test.svg; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to respond" >&2
+          exit 1
+
+      - name: Stop Nagare server
+        if: always()
+        run: |
+          if [ -f nagare/server.pid ]; then
+            kill $(cat nagare/server.pid) 2>/dev/null || true
+            sleep 1
+            if kill -0 $(cat nagare/server.pid) 2>/dev/null; then
+              kill -9 $(cat nagare/server.pid) 2>/dev/null || true
+            fi
+          fi
+          echo '--- Nagare server log ---'
+          cat nagare/server.log || true
+
+      - name: Comment SVG preview on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ ! -f nagare-test.svg ]; then
+            echo "SVG output missing" >&2
+            exit 1
+          fi
+          SVG_ENCODED=$(base64 -w0 nagare-test.svg)
+          cat > comment.md <<COMMENT
+### Nagare /test diagram preview
+<details>
+<summary>Click to expand</summary>
+
+<img alt="Nagare /test preview" src="data:image/svg+xml;base64,${SVG_ENCODED}" />
+</details>
+COMMENT
+          gh pr comment "$PR_NUMBER" --body-file comment.md

--- a/nagare/AGENTS.md
+++ b/nagare/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent Notes for `nagare/`
+
+## Scope
+- Only modify files inside this Go module (`/workspace/nagare/nagare`).
+- Treat sibling directories at the repo root (e.g., `server/`, `nagare-go/`, NodeJS prototypes) as out of scope unless explicitly asked.
+
+## Architecture Overview
+- `cmd/nagare/main.go` exposes `/render` (POST) and `/test` (GET) endpoints. Both run the same four-stage pipeline and respond with generated HTML/SVG.
+- The pipeline is strictly ordered: `tokenizer` ➜ `parser` ➜ `layout` ➜ `renderer`.
+  - `tokenizer/` turns the DSL text into typed tokens (identifiers, braces, @-states, prop punctuation, etc.).
+  - `parser/` builds a shallow AST (max depth 1) with optional named states defined via `@state(...)` blocks whose props are stored for reuse.
+  - `layout/` walks the AST, instantiates concrete component types (e.g., Browser, VM) and assigns grid-based geometry (48-column grid, coordinates in component `Shape`). Props from referenced states are parsed and attached to each component instance.
+  - `renderer/` asks components to render themselves, producing SVG fragments combined into the final document.
+- `components/` contains the SVG/component definitions. Each component carries a `Shape`, optional state metadata, and a `Render` method that returns SVG strings.
+- `props/` provides helpers that parse `key:value` pairs (with quoted strings, ints, etc.) into strongly-typed prop structs used by components.
+
+## Coding Conventions
+- Go code must be formatted with `gofmt` before committing.
+- Organize new logic by extending the existing pipeline stages (tokenizer → parser → layout → renderer) rather than skipping around them.
+- Reuse prop parsing helpers in `props/`; avoid duplicating parsing logic inside components.
+
+## Useful Commands
+- `go test ./...` — run the unit test suite (currently sparse, but keeps the module compiling).
+- `go run ./cmd/nagare` — starts the HTTP server on `localhost:8080` and exercises the sample DSL via `/test`.
+
+## Known Limitations
+- Component type handling in `layout/Calculate` is currently hard-coded for a few types (Browser, VM, Server, etc.); adding a type requires updating this switch and providing a component implementation.
+- Only one level of nesting is supported in the parser; containers cannot contain nested containers beyond depth 1.


### PR DESCRIPTION
## Summary
- add a PR-only workflow that sets up Go, boots the Nagare server, and curls the /test endpoint
- capture the resulting SVG and comment it back on the pull request for quick visual feedback

## Testing
- go test ./... *(fails: existing parser golden expectations are currently out of date)*

------
https://chatgpt.com/codex/tasks/task_e_68d97744d8948328b2232ecd6453cd80