### PR TITLE
Add pixel-based layout sizing with ID-specific overrides

### DIFF
--- a/nagare/cmd/nagare/main.go
+++ b/nagare/cmd/nagare/main.go
@@ -35,12 +35,21 @@ func createDiagram(code string) (string, error) {
 	fmt.Printf("AST: \n%+v\n", ast)
 
 	// 3. Layout
-	const canvasWidth, canvasHeight = 800, 400
-	l := layout.Calculate(ast, canvasWidth, canvasHeight)
+	const defaultCanvasWidth, defaultCanvasHeight = 800.0, 400.0
+	l := layout.Calculate(ast, defaultCanvasWidth, defaultCanvasHeight)
 
 	fmt.Printf("Layout: \n%+v\n", l)
 
-	// 4. Render
+	// 4. Render using the computed layout dimensions
+	canvasWidth := int(l.Bounds.Width)
+	canvasHeight := int(l.Bounds.Height)
+	if canvasWidth == 0 {
+		canvasWidth = int(defaultCanvasWidth)
+	}
+	if canvasHeight == 0 {
+		canvasHeight = int(defaultCanvasHeight)
+	}
+
 	html := renderer.Render(l, canvasWidth, canvasHeight)
 	fmt.Println(html)
 	return html, nil

--- a/nagare/components/browser.go
+++ b/nagare/components/browser.go
@@ -93,11 +93,11 @@ type BrowserTemplateData struct {
 	Text                   string
 }
 
-func (r *Browser) Draw(colWidth, rowHeight float64) string {
+func (r *Browser) Draw(_, _ float64) string {
 	fmt.Println("Drawing browser at", r.X, r.Y, "size", r.Width, r.Height)
 
-	actualWidth := float64(r.Width) * colWidth
-	actualHeight := float64(r.Height) * rowHeight
+	actualWidth := r.Width
+	actualHeight := r.Height
 
 	// Calculate all dimensions
 	cornerRadius := actualWidth * 0.015625        // 10/640
@@ -118,8 +118,8 @@ func (r *Browser) Draw(colWidth, rowHeight float64) string {
 
 	// Create template data
 	data := BrowserTemplateData{
-		X:                      float64(r.X) * colWidth,
-		Y:                      float64(r.Y) * rowHeight,
+		X:                      r.X,
+		Y:                      r.Y,
 		Width:                  actualWidth,
 		Height:                 actualHeight,
 		CornerRadius:           cornerRadius,

--- a/nagare/components/rectangle.go
+++ b/nagare/components/rectangle.go
@@ -3,14 +3,14 @@ package components
 import "fmt"
 
 type Component interface {
-	Draw(colWidth, rowHeight float64) string
+	Draw(xScale, yScale float64) string
 }
 
 type Shape struct {
-	Width  int
-	Height int
-	X      int
-	Y      int
+	Width  float64
+	Height float64
+	X      float64
+	Y      float64
 }
 
 type Rectangle struct {
@@ -18,35 +18,35 @@ type Rectangle struct {
 	Text string
 }
 
-func (r *Rectangle) Draw(colWidth, rowHeight float64) string {
+func (r *Rectangle) Draw(_, _ float64) string {
 	fmt.Println("Drawing rectangle:", r.Text, "at", r.X, r.Y, "size", r.Width, r.Height)
 	return fmt.Sprintf(`
-	<g transform="translate(%f,%f)">
-		<!-- Element rectangle -->
-		<rect
-			x="0"
-			y="0"
-			width="%f"
-			height="%f"
-			fill="#333333"
-			stroke="#cccccc"
-			stroke-width="2"/>
+        <g transform="translate(%f,%f)">
+                <!-- Element rectangle -->
+                <rect
+                        x="0"
+                        y="0"
+                        width="%f"
+                        height="%f"
+                        fill="#333333"
+                        stroke="#cccccc"
+                        stroke-width="2"/>
 
-		<!-- Text -->
-		<text
-			x="%f"
-			y="%f"
-			font-family="Arial"
-			font-size="14"
-			fill="#cccccc"
-			text-anchor="middle"
-			dominant-baseline="middle">
-			%s
-		</text>
-	</g>`,
-		float64(r.X)*colWidth, float64(r.Y)*rowHeight,
-		float64(r.Width)*colWidth, float64(r.Height)*rowHeight,
-		float64(r.Width/2)*colWidth, float64(r.Height/2)*rowHeight,
+                <!-- Text -->
+                <text
+                        x="%f"
+                        y="%f"
+                        font-family="Arial"
+                        font-size="14"
+                        fill="#cccccc"
+                        text-anchor="middle"
+                        dominant-baseline="middle">
+                        %s
+                </text>
+        </g>`,
+		r.X, r.Y,
+		r.Width, r.Height,
+		r.Width/2, r.Height/2,
 		r.Text,
 	)
 }

--- a/nagare/components/server.go
+++ b/nagare/components/server.go
@@ -70,9 +70,9 @@ func (s *Server) Configure(props string) error {
 }
 
 // Draw implements the Component interface
-func (s *Server) Draw(colWidth, rowHeight float64) string {
-	actualWidth := float64(s.Width) * colWidth
-	actualHeight := float64(s.Height) * rowHeight
+func (s *Server) Draw(_, _ float64) string {
+	actualWidth := s.Width
+	actualHeight := s.Height
 
 	data := struct {
 		X      float64
@@ -82,8 +82,8 @@ func (s *Server) Draw(colWidth, rowHeight float64) string {
 		Props  ServerProps
 		Text   string
 	}{
-		X:      float64(s.X) * colWidth,
-		Y:      float64(s.Y) * rowHeight,
+		X:      s.X,
+		Y:      s.Y,
 		Width:  actualWidth,
 		Height: actualHeight,
 		Props:  s.Props,

--- a/nagare/layout/layout.go
+++ b/nagare/layout/layout.go
@@ -4,10 +4,17 @@ import (
 	"fmt"
 	"nagare/components"
 	"nagare/parser"
+	"nagare/props"
+	"strings"
 )
 
 const (
-	DefaultColumns = 48
+	defaultBrowserWidth  = 640.0
+	defaultBrowserHeight = 420.0
+	defaultVMWidth       = 640.0
+	defaultVMHeight      = 420.0
+	defaultServerWidth   = 200.0
+	defaultServerHeight  = 140.0
 )
 
 // Rect represents a rectangle in the layout
@@ -24,183 +31,192 @@ type Layout struct {
 	Children []components.Component
 }
 
-// func (n Layout) String() string {
-// 	if len(n.Children) == 0 {
-// 		return n.Text
-// 	}
+type geometryProps struct {
+	X      *int `prop:"x"`
+	Y      *int `prop:"y"`
+	Width  *int `prop:"w"`
+	Height *int `prop:"h"`
+}
 
-// 	childrenStr := ""
+func parseGeometry(def string) (geometryProps, error) {
+	geom := geometryProps{}
+	if strings.TrimSpace(def) == "" {
+		return geom, nil
+	}
+	if err := props.ParseProps(def, &geom); err != nil {
+		return geom, err
+	}
+	return geom, nil
+}
 
-// 	for _, child := range n.Children {
-// 		childrenStr += "[ " + child.String() + " ]"
-// 	}
-
-// 	return fmt.Sprintf("%s [%s]", n.Text, childrenStr)
-
-// }
-
-// const (
-// 	mainPadding     = 16.0 // Padding for the main layout
-// 	subPadding      = 8.0  // Padding for nested layouts
-// 	titleHeight     = 40.0 // Height reserved for container title
-// 	titleTopPadding = 20.0 // Padding above the container title
-// )
+func applyGeometry(shape *components.Shape, geom geometryProps) {
+	if geom.Width != nil {
+		shape.Width = float64(*geom.Width)
+	}
+	if geom.Height != nil {
+		shape.Height = float64(*geom.Height)
+	}
+	if geom.X != nil {
+		shape.X = float64(*geom.X)
+	}
+	if geom.Y != nil {
+		shape.Y = float64(*geom.Y)
+	}
+}
 
 // Calculate computes the layout for an AST
 func Calculate(node parser.Node, canvasWidth, canvasHeight float64) Layout {
-	// columns := 12
-	// columnsWidth := float64(canvasWidth) / float64(columns)
-	// rows := canvasHeight / columnsWidth
-	// rowsHeight := canvasHeight / rows
+	boundsWidth := canvasWidth
+	boundsHeight := canvasHeight
 
-	// rectWidth := 3 * columnsWidth
-	// rectHeight := 2 * rowsHeight
+	if layoutState, ok := node.Globals["layout"]; ok {
+		if geom, err := parseGeometry(layoutState.PropsDef); err == nil {
+			if geom.Width != nil {
+				boundsWidth = float64(*geom.Width)
+			}
+			if geom.Height != nil {
+				boundsHeight = float64(*geom.Height)
+			}
+		} else {
+			fmt.Printf("failed to parse @layout props: %v\n", err)
+		}
+	}
 
-	// if node.Type == parser.NODE_CONTAINER {
-	// 	// Container node
-	// 	childLayouts := make([]Layout, len(node.Children))
+	children := make([]components.Component, 0, len(node.Children))
 
-	// 	// Calculate total width needed for children in a row
-	// 	childrenWidth := float64(len(node.Children)) * (rectWidth + mainPadding)
-	// 	containerWidth := max(childrenWidth, 260.0) // Min container width
-
-	// 	// Calculate height needed for container with title and children
-	// 	containerHeight := rectHeight + titleHeight + mainPadding*2
-
-	// 	// Position children in a row
-	// 	for i, child := range node.Children {
-	// 		childX := float64(i) * (rectWidth + mainPadding)
-	// 		childLayout := Calculate(child, rectWidth, rectHeight)
-	// 		childLayout.Bounds.X = childX
-	// 		childLayout.Bounds.Y = 0 // Y offset handled by group transform in renderer
-	// 		childLayouts[i] = childLayout
-	// 	}
-
-	// 	// Center container in its allocated space
-	// 	return Layout{
-	// 		Bounds: Rect{
-	// 			X:      (canvasWidth - containerWidth) / 2,
-	// 			Y:      mainPadding,
-	// 			Width:  containerWidth,
-	// 			Height: containerHeight,
-	// 		},
-	// 		Text:     node.Text,
-	// 		Children: childLayouts,
-	// 	}
-	// }
-
-	// if node.Text == "" {
-	// 	// Root node - arrange children horizontally with equal spacing
-	// 	childLayouts := make([]Layout, len(node.Children))
-	// 	spacing := float64(canvasWidth) / float64(len(node.Children)+1)
-
-	// 	for i, child := range node.Children {
-	// 		childX := spacing*float64(i+1) - rectWidth/2
-	// 		childLayout := Calculate(child, rectWidth*2, canvasHeight-mainPadding*2)
-	// 		childLayout.Bounds.X = childX
-	// 		childLayout.Bounds.Y = mainPadding
-	// 		childLayouts[i] = childLayout
-	// 	}
-
-	// 	return Layout{
-	// 		Bounds: Rect{
-	// 			X:      0,
-	// 			Y:      0,
-	// 			Width:  canvasWidth,
-	// 			Height: canvasHeight,
-	// 		},
-	// 		Children: childLayouts,
-	// 	}
-	// }
-
-	// We start with the root node being a container.
-	// Ignore it and go straight to its children.
-	children := make([]components.Component, len(node.Children))
-	for i, child := range node.Children {
-
-		// FIME: HARDCODED TYPES
-		if child.Type == "Browser" {
+	for _, child := range node.Children {
+		switch child.Type {
+		case "Browser":
 			browser := components.NewBrowser()
 			browser.Shape = components.Shape{
-				Width:  12, // Based on Grid system. 3 cells x 2 cells
-				Height: 12,
-				X:      1, // 3 cells width + 1 cell gap
-				Y:      1,
+				Width:  defaultBrowserWidth,
+				Height: defaultBrowserHeight,
+				X:      0,
+				Y:      0,
 			}
 
-			// Set state and parse props if state exists
+			if idState, ok := child.States[child.Text]; ok {
+				if geom, err := parseGeometry(idState.PropsDef); err == nil {
+					applyGeometry(&browser.Shape, geom)
+				} else {
+					fmt.Printf("failed to parse geometry for %s: %v\n", child.Text, err)
+				}
+
+				if err := browser.Props.Parse(idState.PropsDef); err != nil {
+					fmt.Printf("failed to parse props for %s: %v\n", child.Text, err)
+				}
+			}
+
 			if child.State != "" {
 				if state, ok := child.States[child.State]; ok {
 					browser.State = state.Name
-					// Parse props for this state
-					browser.Props.Parse(state.PropsDef)
+					if err := browser.Props.Parse(state.PropsDef); err != nil {
+						fmt.Printf("failed to parse props for state %s: %v\n", state.Name, err)
+					}
 				}
 			}
 
-			children[i] = browser
+			children = append(children, browser)
 			fmt.Printf("State: %s, Props: %+v\n", browser.State, browser.Props)
-			continue
-		}
-		if child.Type == "VM" {
+		case "VM":
 			vm := components.NewVM()
 			vm.Shape = components.Shape{
-				Width:  28, // Based on Grid system. 3 cells x 2 cells
-				Height: 20,
-				X:      20, // 3 cells width + 1 cell gap
-				Y:      1,
+				Width:  defaultVMWidth,
+				Height: defaultVMHeight,
+				X:      0,
+				Y:      0,
 			}
 
-			// Set state and parse props if state exists
+			if idState, ok := child.States[child.Text]; ok {
+				if geom, err := parseGeometry(idState.PropsDef); err == nil {
+					applyGeometry(&vm.Shape, geom)
+				} else {
+					fmt.Printf("failed to parse geometry for %s: %v\n", child.Text, err)
+				}
+
+				if err := vm.Props.Parse(idState.PropsDef); err != nil {
+					fmt.Printf("failed to parse props for %s: %v\n", child.Text, err)
+				}
+			}
+
 			if child.State != "" {
 				if state, ok := child.States[child.State]; ok {
 					vm.State = state.Name
-					// Parse props for this state
-					vm.Props.Parse(state.PropsDef)
+					if err := vm.Props.Parse(state.PropsDef); err != nil {
+						fmt.Printf("failed to parse props for state %s: %v\n", state.Name, err)
+					}
 				}
 			}
 
-			// Process VM's children if any
 			if len(child.Children) > 0 {
-				childComponents := make([]components.Component, len(child.Children))
-				for j, grandchild := range child.Children {
+				childComponents := make([]components.Component, 0, len(child.Children))
+				contentOffsetX := vm.Shape.X + vm.Shape.Width*components.VMContentAreaXRatio
+				contentOffsetY := vm.Shape.Y + vm.Shape.Height*components.VMContentAreaYRatio
+
+				for _, grandchild := range child.Children {
 					switch grandchild.Type {
 					case "Server":
 						server := components.NewServer(grandchild.Text)
 						server.Shape = components.Shape{
-							Width:  12,
-							Height: 3,
-							X:      1,
-							Y:      j*4 + 1, // Stack vertically with spacing
+							Width:  defaultServerWidth,
+							Height: defaultServerHeight,
+							X:      0,
+							Y:      0,
 						}
+
+						if idState, ok := grandchild.States[grandchild.Text]; ok {
+							geom, err := parseGeometry(idState.PropsDef)
+							if err == nil {
+								if geom.Width != nil {
+									server.Shape.Width = float64(*geom.Width)
+								}
+								if geom.Height != nil {
+									server.Shape.Height = float64(*geom.Height)
+								}
+								if geom.X != nil {
+									server.Shape.X = float64(*geom.X) - contentOffsetX
+								}
+								if geom.Y != nil {
+									server.Shape.Y = float64(*geom.Y) - contentOffsetY
+								}
+							} else {
+								fmt.Printf("failed to parse geometry for %s: %v\n", grandchild.Text, err)
+							}
+
+							if err := server.Props.Parse(idState.PropsDef); err != nil {
+								fmt.Printf("failed to parse props for %s: %v\n", grandchild.Text, err)
+							}
+						}
+
 						if grandchild.State != "" {
 							if state, ok := grandchild.States[grandchild.State]; ok {
 								server.State = state.Name
-								server.Props.Parse(state.PropsDef)
+								if err := server.Props.Parse(state.PropsDef); err != nil {
+									fmt.Printf("failed to parse props for state %s: %v\n", state.Name, err)
+								}
 							}
 						}
-						childComponents[j] = server
-					// Add other types as needed
+
+						childComponents = append(childComponents, server)
 					default:
 						fmt.Printf("Unknown child type: %s\n", grandchild.Type)
-						continue
 					}
 				}
 				vm.Children = childComponents
 			}
 
-			children[i] = vm
+			children = append(children, vm)
 			fmt.Printf("State: %s, Props: %+v\n", vm.State, vm.Props)
-			continue
-		} else {
-			children[i] = &components.Rectangle{
+		default:
+			children = append(children, &components.Rectangle{
 				Shape: components.Shape{
-					Width:  3, // Based on Grid system. 3 cells x 2 cells
-					Height: 2,
-					X:      int(float64(i*4) + 1), // 3 cells width + 1 cell gap
+					Width:  defaultServerWidth,
+					Height: defaultServerHeight,
+					X:      0,
 					Y:      0,
 				},
 				Text: child.Text,
-			}
+			})
 		}
 	}
 
@@ -208,31 +224,9 @@ func Calculate(node parser.Node, canvasWidth, canvasHeight float64) Layout {
 		Bounds: Rect{
 			X:      0,
 			Y:      0,
-			Width:  canvasWidth,
-			Height: canvasHeight,
+			Width:  boundsWidth,
+			Height: boundsHeight,
 		},
 		Children: children,
 	}
-
 }
-
-// func max(a, b float64) float64 {
-// 	if a > b {
-// 		return a
-// 	}
-// 	return b
-// }
-
-// func min(a, b int) int {
-// 	if a < b {
-// 		return a
-// 	}
-// 	return b
-// }
-
-// func minf(a, b float64) float64 {
-// 	if a < b {
-// 		return a
-// 	}
-// 	return b
-// }

--- a/nagare/props/props.go
+++ b/nagare/props/props.go
@@ -110,6 +110,21 @@ func ParseProps(input string, target interface{}) error {
 					} else {
 						return fmt.Errorf("failed to parse %q as integer for field %s: %v", value, field.Name, err)
 					}
+				case reflect.Ptr:
+					elemType := fieldValue.Type().Elem()
+					switch elemType.Kind() {
+					case reflect.String:
+						strValue := value
+						fieldValue.Set(reflect.ValueOf(&strValue))
+					case reflect.Int:
+						if intValue, err := strconv.Atoi(value); err == nil {
+							fieldValue.Set(reflect.ValueOf(&intValue))
+						} else {
+							return fmt.Errorf("failed to parse %q as integer for field %s: %v", value, field.Name, err)
+						}
+					default:
+						return fmt.Errorf("unsupported pointer type for field %s", field.Name)
+					}
 				}
 
 				found = true

--- a/nagare/renderer/renderer.go
+++ b/nagare/renderer/renderer.go
@@ -145,15 +145,10 @@ import (
 // 	)
 // }
 
-func renderChildren(canvasWidth int, canvasHeight int, children []components.Component) string {
-	columns := 48
-	columnsWidth := float64(canvasWidth / columns)
-	rows := float64(canvasHeight) / columnsWidth
-	rowsHeight := float64(canvasHeight) / rows
-
-	var elements string = ""
+func renderChildren(children []components.Component) string {
+	var elements string
 	for _, child := range children {
-		elements += child.Draw(columnsWidth, float64(rowsHeight))
+		elements += child.Draw(1, 1)
 	}
 	return elements
 }
@@ -182,14 +177,14 @@ func drawGrid(canvasWidth, canvasHeight int) string {
 func Render(l layout.Layout, canvasWidth, canvasHeight int) string {
 	// Create the SVG wrapper with background and the layout
 	return fmt.Sprintf(`<svg width="%d" height="%d" xmlns="http://www.w3.org/2000/svg">
-	<!-- Background -->
-	<rect width="%d" height="%d" fill="#ffffff"/>
-	%s
-	%s
+        <!-- Background -->
+        <rect width="%d" height="%d" fill="#ffffff"/>
+        %s
+        %s
 </svg>`,
 		canvasWidth, canvasHeight,
 		canvasWidth, canvasHeight,
 		drawGrid(canvasWidth, canvasHeight),
-		renderChildren(canvasWidth, canvasHeight, l.Children),
+		renderChildren(l.Children),
 	)
 }


### PR DESCRIPTION
## Summary
- read layout geometry from the `@layout` state and pass the computed size to the renderer
- treat component shapes as pixel-based values while layering ID props before type props
- allow optional geometry parsing and track global/ID states during parsing for layout consumption

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dae7d944148328a2fdeca3c13b8128