### PR TITLE
Fix server layout geometry resolution

### DIFF
--- a/nagare/cmd/nagare/main.go
+++ b/nagare/cmd/nagare/main.go
@@ -35,12 +35,21 @@ func createDiagram(code string) (string, error) {
 	fmt.Printf("AST: \n%+v\n", ast)
 
 	// 3. Layout
-	const canvasWidth, canvasHeight = 800, 400
-	l := layout.Calculate(ast, canvasWidth, canvasHeight)
+	const defaultCanvasWidth, defaultCanvasHeight = 800.0, 400.0
+	l := layout.Calculate(ast, defaultCanvasWidth, defaultCanvasHeight)
 
 	fmt.Printf("Layout: \n%+v\n", l)
 
-	// 4. Render
+	// 4. Render using the computed layout dimensions
+	canvasWidth := int(l.Bounds.Width)
+	canvasHeight := int(l.Bounds.Height)
+	if canvasWidth == 0 {
+		canvasWidth = int(defaultCanvasWidth)
+	}
+	if canvasHeight == 0 {
+		canvasHeight = int(defaultCanvasHeight)
+	}
+
 	html := renderer.Render(l, canvasWidth, canvasHeight)
 	fmt.Println(html)
 	return html, nil

--- a/nagare/components/browser.go
+++ b/nagare/components/browser.go
@@ -93,11 +93,11 @@ type BrowserTemplateData struct {
 	Text                   string
 }
 
-func (r *Browser) Draw(colWidth, rowHeight float64) string {
+func (r *Browser) Draw(_, _ float64) string {
 	fmt.Println("Drawing browser at", r.X, r.Y, "size", r.Width, r.Height)
 
-	actualWidth := float64(r.Width) * colWidth
-	actualHeight := float64(r.Height) * rowHeight
+	actualWidth := r.Width
+	actualHeight := r.Height
 
 	// Calculate all dimensions
 	cornerRadius := actualWidth * 0.015625        // 10/640
@@ -118,8 +118,8 @@ func (r *Browser) Draw(colWidth, rowHeight float64) string {
 
 	// Create template data
 	data := BrowserTemplateData{
-		X:                      float64(r.X) * colWidth,
-		Y:                      float64(r.Y) * rowHeight,
+		X:                      r.X,
+		Y:                      r.Y,
 		Width:                  actualWidth,
 		Height:                 actualHeight,
 		CornerRadius:           cornerRadius,

--- a/nagare/components/rectangle.go
+++ b/nagare/components/rectangle.go
@@ -3,14 +3,14 @@ package components
 import "fmt"
 
 type Component interface {
-	Draw(colWidth, rowHeight float64) string
+	Draw(xScale, yScale float64) string
 }
 
 type Shape struct {
-	Width  int
-	Height int
-	X      int
-	Y      int
+	Width  float64
+	Height float64
+	X      float64
+	Y      float64
 }
 
 type Rectangle struct {
@@ -18,35 +18,35 @@ type Rectangle struct {
 	Text string
 }
 
-func (r *Rectangle) Draw(colWidth, rowHeight float64) string {
+func (r *Rectangle) Draw(_, _ float64) string {
 	fmt.Println("Drawing rectangle:", r.Text, "at", r.X, r.Y, "size", r.Width, r.Height)
 	return fmt.Sprintf(`
-	<g transform="translate(%f,%f)">
-		<!-- Element rectangle -->
-		<rect
-			x="0"
-			y="0"
-			width="%f"
-			height="%f"
-			fill="#333333"
-			stroke="#cccccc"
-			stroke-width="2"/>
+        <g transform="translate(%f,%f)">
+                <!-- Element rectangle -->
+                <rect
+                        x="0"
+                        y="0"
+                        width="%f"
+                        height="%f"
+                        fill="#333333"
+                        stroke="#cccccc"
+                        stroke-width="2"/>
 
-		<!-- Text -->
-		<text
-			x="%f"
-			y="%f"
-			font-family="Arial"
-			font-size="14"
-			fill="#cccccc"
-			text-anchor="middle"
-			dominant-baseline="middle">
-			%s
-		</text>
-	</g>`,
-		float64(r.X)*colWidth, float64(r.Y)*rowHeight,
-		float64(r.Width)*colWidth, float64(r.Height)*rowHeight,
-		float64(r.Width/2)*colWidth, float64(r.Height/2)*rowHeight,
+                <!-- Text -->
+                <text
+                        x="%f"
+                        y="%f"
+                        font-family="Arial"
+                        font-size="14"
+                        fill="#cccccc"
+                        text-anchor="middle"
+                        dominant-baseline="middle">
+                        %s
+                </text>
+        </g>`,
+		r.X, r.Y,
+		r.Width, r.Height,
+		r.Width/2, r.Height/2,
 		r.Text,
 	)
 }

--- a/nagare/components/server.go
+++ b/nagare/components/server.go
@@ -70,9 +70,9 @@ func (s *Server) Configure(props string) error {
 }
 
 // Draw implements the Component interface
-func (s *Server) Draw(colWidth, rowHeight float64) string {
-	actualWidth := float64(s.Width) * colWidth
-	actualHeight := float64(s.Height) * rowHeight
+func (s *Server) Draw(_, _ float64) string {
+	actualWidth := s.Width
+	actualHeight := s.Height
 
 	data := struct {
 		X      float64
@@ -82,8 +82,8 @@ func (s *Server) Draw(colWidth, rowHeight float64) string {
 		Props  ServerProps
 		Text   string
 	}{
-		X:      float64(s.X) * colWidth,
-		Y:      float64(s.Y) * rowHeight,
+		X:      s.X,
+		Y:      s.Y,
 		Width:  actualWidth,
 		Height: actualHeight,
 		Props:  s.Props,

--- a/nagare/props/props.go
+++ b/nagare/props/props.go
@@ -110,6 +110,21 @@ func ParseProps(input string, target interface{}) error {
 					} else {
 						return fmt.Errorf("failed to parse %q as integer for field %s: %v", value, field.Name, err)
 					}
+				case reflect.Ptr:
+					elemType := fieldValue.Type().Elem()
+					switch elemType.Kind() {
+					case reflect.String:
+						strValue := value
+						fieldValue.Set(reflect.ValueOf(&strValue))
+					case reflect.Int:
+						if intValue, err := strconv.Atoi(value); err == nil {
+							fieldValue.Set(reflect.ValueOf(&intValue))
+						} else {
+							return fmt.Errorf("failed to parse %q as integer for field %s: %v", value, field.Name, err)
+						}
+					default:
+						return fmt.Errorf("unsupported pointer type for field %s", field.Name)
+					}
 				}
 
 				found = true

--- a/nagare/renderer/renderer.go
+++ b/nagare/renderer/renderer.go
@@ -145,15 +145,10 @@ import (
 // 	)
 // }
 
-func renderChildren(canvasWidth int, canvasHeight int, children []components.Component) string {
-	columns := 48
-	columnsWidth := float64(canvasWidth / columns)
-	rows := float64(canvasHeight) / columnsWidth
-	rowsHeight := float64(canvasHeight) / rows
-
-	var elements string = ""
+func renderChildren(children []components.Component) string {
+	var elements string
 	for _, child := range children {
-		elements += child.Draw(columnsWidth, float64(rowsHeight))
+		elements += child.Draw(1, 1)
 	}
 	return elements
 }
@@ -182,14 +177,14 @@ func drawGrid(canvasWidth, canvasHeight int) string {
 func Render(l layout.Layout, canvasWidth, canvasHeight int) string {
 	// Create the SVG wrapper with background and the layout
 	return fmt.Sprintf(`<svg width="%d" height="%d" xmlns="http://www.w3.org/2000/svg">
-	<!-- Background -->
-	<rect width="%d" height="%d" fill="#ffffff"/>
-	%s
-	%s
+        <!-- Background -->
+        <rect width="%d" height="%d" fill="#ffffff"/>
+        %s
+        %s
 </svg>`,
 		canvasWidth, canvasHeight,
 		canvasWidth, canvasHeight,
 		drawGrid(canvasWidth, canvasHeight),
-		renderChildren(canvasWidth, canvasHeight, l.Children),
+		renderChildren(l.Children),
 	)
 }


### PR DESCRIPTION
## Summary
- resolve state lookups against per-node and global definitions so ID props load even when declared before usage
- apply geometry overrides from both ID and type props for browsers, VMs, and servers including nested server offsets
- share helper logic for adjusting server coordinates relative to the VM content area

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dae7d944148328a2fdeca3c13b8128