### PR TITLE
Support standalone servers and configurable rectangles

### DIFF
--- a/.github/pr-images/pr-31/nagare-test.svg
+++ b/.github/pr-images/pr-31/nagare-test.svg
@@ -1,0 +1,113 @@
+<svg width="950" height="400" xmlns="http://www.w3.org/2000/svg">
+        <!-- Background -->
+        <rect width="950" height="400" fill="#ffffff"/>
+        
+        <g transform="translate(50.000000,100.000000)">
+                <g class="ns" filter="url(#softShadow)">
+                        <rect x="0" y="0" width="200.000000" height="150.000000" rx="3.125000" fill="#e6f3ff" stroke="#333"/>
+                        <rect x="0" y="0" width="200.000000" height="15.714285" rx="3.125000" ry="3.125000" fill="#e6f3ff" stroke="#333"/>
+                        <rect x="31.250000" y="3.571425" width="150.000000" height="8.571420" rx="1.875000" fill="#fff" stroke="#333" opacity="0.85"/>
+                        <rect x="3.750000" y="19.999995" width="192.500000" height="125.714280" rx="1.875000" fill="#ffffff" stroke="#333" opacity="0.9"/>
+                </g>
+                <text x="106.250000" y="7.857135" text-anchor="middle" dominant-baseline="middle"
+                        font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif"
+                        font-size="8.000000" fill="#333">https://www.nagare.com</text>
+                <text x="100.000000" y="82.857135" text-anchor="middle" dominant-baseline="middle"
+                        font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif"
+                        font-size="20" fill="#333">Home Page</text>
+                <g transform="translate(4.375000,4.999995)">
+                        <circle r="1.875000" cx="0" cy="2.493750" fill="#ff5f57"/>
+                        <circle r="1.875000" cx="5.625000" cy="2.493750" fill="#febc2e"/>
+                        <circle r="1.875000" cx="11.250000" cy="2.493750" fill="#28c840"/>
+                </g>
+        </g><g transform="translate(300.000000,25.000000)">
+                <g class="ns" filter="url(#softShadow)">
+                        <rect x="0" y="0" width="600.000000" height="300.000000" rx="9.375000" fill="#333" stroke="#ccc"/>
+                        <rect x="0" y="0" width="600.000000" height="31.428570" rx="9.375000" ry="9.375000" fill="#333" stroke="#ccc"/>
+                        <rect x="11.250000" y="39.999990" width="577.500000" height="251.428560" rx="5.625000" fill="#ccc" stroke="#ccc" opacity="0.9"/>
+                </g>
+                <g transform="translate(13.125000,9.999990)">
+                        <circle r="5.625000" cx="0" cy="7.481250" fill="#ff5f57"/>
+                        <circle r="5.625000" cx="16.875000" cy="7.481250" fill="#febc2e"/>
+                        <circle r="5.625000" cx="33.750000" cy="7.481250" fill="#28c840"/>
+                        <!-- Title text positioned after controls -->
+                        <text x="61.875000" 
+                              y="7.481250" 
+                              text-anchor="start" 
+                              dominant-baseline="middle"
+                              font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif"
+                              font-size="30" 
+                              fill="#ccc">home@ubuntu</text>
+                </g>
+        </g><g transform="translate(311.250000,64.999990)">
+<g transform="translate(50.000000,85.000010)">
+    <!-- Main server box -->
+    <rect x="0" y="0" width="200.000000" height="50.000000" 
+          rx="5.000000" ry="5.000000" 
+          fill="#e6f3ff" stroke="#333" stroke-width="2"/>
+    
+    <!-- Icon -->
+    
+    
+    <g transform="translate(7.500000,7.500000)">
+        
+        <!-- Nginx icon -->
+        <rect x="0" y="0" width="35.000000" height="35.000000" fill="#009639"/>
+        <text x="17.500000" y="24.500000" 
+              fill="#ffffff" font-family="Arial" font-size="21.000000" 
+              text-anchor="middle">N</text>
+        
+    </g>
+    
+    <!-- Title -->
+    <text x="57.500000" 
+          y="30.000000" 
+          fill="#333" 
+          font-family="Arial" 
+          font-size="20.000000"
+          >nginx</text>
+    
+    <!-- Port display -->
+    <text x="192.500000" 
+          y="30.000000" 
+          fill="#333" 
+          font-family="Arial" 
+          font-size="17.500000"
+          text-anchor="end">:80</text>
+</g>
+<g transform="translate(350.000000,85.000010)">
+    <!-- Main server box -->
+    <rect x="0" y="0" width="200.000000" height="50.000000" 
+          rx="5.000000" ry="5.000000" 
+          fill="#f0f8ff" stroke="#333" stroke-width="2"/>
+    
+    <!-- Icon -->
+    
+    
+    <g transform="translate(7.500000,7.500000)">
+        
+        <!-- Golang icon -->
+        <rect x="0" y="0" width="35.000000" height="35.000000" fill="#00ADD8"/>
+        <text x="17.500000" y="24.500000" 
+              fill="#ffffff" font-family="Arial" font-size="21.000000" 
+              text-anchor="middle">Go</text>
+        
+    </g>
+    
+    <!-- Title -->
+    <text x="57.500000" 
+          y="30.000000" 
+          fill="#333" 
+          font-family="Arial" 
+          font-size="20.000000"
+          >App</text>
+    
+    <!-- Port display -->
+    <text x="192.500000" 
+          y="30.000000" 
+          fill="#333" 
+          font-family="Arial" 
+          font-size="17.500000"
+          text-anchor="end">:8080</text>
+</g></g><g class="connector"><defs><marker id="arrowhead-1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/></marker></defs><polyline points="250.00,175.00 361.25,175.00" stroke="#1f2937" stroke-width="2.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead-1)"/></g><g class="connector"><defs><marker id="arrowhead-2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/></marker></defs><polyline points="561.25,175.00 661.25,175.00" stroke="#1f2937" stroke-width="2.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead-2)"/></g>
+</svg>

--- a/.github/workflows/render-preview.yml
+++ b/.github/workflows/render-preview.yml
@@ -19,20 +19,17 @@ jobs:
           go-version: '1.24.x'
           cache: true
           cache-dependency-path: |
-            nagare/go.mod
-            nagare/go.sum
+            go.mod
+            go.sum
 
       - name: Download dependencies
-        working-directory: nagare
         run: go mod download
 
       - name: Build Nagare server
-        working-directory: nagare
-        run: go build -o nagare-server ./cmd/nagare
+        run: go build -o nagare-server ./cmd
 
       - name: Start Nagare server
         run: |
-          cd nagare
           ./nagare-server > server.log 2>&1 &
           echo $! > server.pid
 
@@ -50,15 +47,15 @@ jobs:
       - name: Stop Nagare server
         if: always()
         run: |
-          if [ -f nagare/server.pid ]; then
-            kill $(cat nagare/server.pid) 2>/dev/null || true
+          if [ -f server.pid ]; then
+            kill $(cat server.pid) 2>/dev/null || true
             sleep 1
-            if kill -0 $(cat nagare/server.pid) 2>/dev/null; then
-              kill -9 $(cat nagare/server.pid) 2>/dev/null || true
+            if kill -0 $(cat server.pid) 2>/dev/null; then
+              kill -9 $(cat server.pid) 2>/dev/null || true
             fi
           fi
           echo '--- Nagare server log ---'
-          cat nagare/server.log || true
+          cat server.log || true
 
       - name: Upload SVGs to repository and create PR comment
         env:

--- a/pkg/components/rectangle.go
+++ b/pkg/components/rectangle.go
@@ -1,6 +1,12 @@
 package components
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/saasuke-labs/nagare/pkg/props"
+)
 
 type Component interface {
 	Draw() string
@@ -14,40 +20,88 @@ type Shape struct {
 	AlignmentRefs map[string]string // Store alignment references for later resolution
 }
 
+type RectangleProps struct {
+	Title           string `prop:"title"`
+	BackgroundColor string `prop:"bg"`
+	ForegroundColor string `prop:"fg"`
+}
+
+func (r *RectangleProps) Parse(input string) error {
+	return props.ParseProps(input, r)
+}
+
+func DefaultRectangleProps() RectangleProps {
+	return RectangleProps{
+		Title:           "",
+		BackgroundColor: "#e6f3ff",
+		ForegroundColor: "#333333",
+	}
+}
+
 type Rectangle struct {
 	Shape
-	Text string
+	Text  string
+	Props RectangleProps
+	State string
+}
+
+func NewRectangle(id string) *Rectangle {
+	return &Rectangle{
+		Text:  id,
+		Props: DefaultRectangleProps(),
+	}
 }
 
 func (r *Rectangle) Draw() string {
-	fmt.Println("Drawing rectangle:", r.Text, "at", r.X, r.Y, "size", r.Width, r.Height)
-	return fmt.Sprintf(`
-        <g transform="translate(%f,%f)">
-                <!-- Element rectangle -->
-                <rect
-                        x="0"
-                        y="0"
-                        width="%f"
-                        height="%f"
-                        fill="#333333"
-                        stroke="#cccccc"
-                        stroke-width="2"/>
+	displayText := r.Text
+	if r.Props.Title != "" {
+		displayText = r.Props.Title
+	}
 
-                <!-- Text -->
-                <text
-                        x="%f"
-                        y="%f"
-                        font-family="Arial"
-                        font-size="14"
-                        fill="#cccccc"
-                        text-anchor="middle"
-                        dominant-baseline="middle">
-                        %s
-                </text>
-        </g>`,
-		r.X, r.Y,
-		r.Width, r.Height,
-		r.Width/2, r.Height/2,
-		r.Text,
-	)
+	data := struct {
+		X             float64
+		Y             float64
+		Width         float64
+		Height        float64
+		DisplayText   string
+		Background    string
+		Foreground    string
+		BorderRadiusX float64
+		BorderRadiusY float64
+	}{
+		X:             r.X,
+		Y:             r.Y,
+		Width:         r.Width,
+		Height:        r.Height,
+		DisplayText:   displayText,
+		Background:    r.Props.BackgroundColor,
+		Foreground:    r.Props.ForegroundColor,
+		BorderRadiusX: r.Height * 0.1,
+		BorderRadiusY: r.Height * 0.1,
+	}
+
+	const rectangleTemplate = `<g transform="translate({{printf "%.6f" .X}},{{printf "%.6f" .Y}})">
+    <rect x="0" y="0" width="{{printf "%.6f" .Width}}" height="{{printf "%.6f" .Height}}"
+          rx="{{printf "%.6f" .BorderRadiusX}}" ry="{{printf "%.6f" .BorderRadiusY}}"
+          fill="{{.Background}}" stroke="{{.Foreground}}" stroke-width="2"/>
+    <text x="{{printf "%.6f" (mul .Width 0.5)}}" y="{{printf "%.6f" (mul .Height 0.5)}}"
+          font-family="Arial" font-size="14" fill="{{.Foreground}}"
+          text-anchor="middle" dominant-baseline="middle">{{.DisplayText}}</text>
+</g>`
+
+	funcMap := template.FuncMap{
+		"mul": func(a, b float64) float64 { return a * b },
+	}
+
+	tmpl, err := template.New("rectangle").Funcs(funcMap).Parse(rectangleTemplate)
+	if err != nil {
+		return fmt.Sprintf("<!-- Error parsing rectangle template: %v -->", err)
+	}
+
+	var svg bytes.Buffer
+	if err := tmpl.Execute(&svg, data); err != nil {
+		return fmt.Sprintf("<!-- Error executing rectangle template: %v -->", err)
+	}
+
+	return svg.String()
 }


### PR DESCRIPTION
## Summary
- allow server components to be rendered outside of VM containers while preserving geometry
- add a configurable rectangle component that respects state geometry and styling props by default

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de1d3de1688328a4a5e97b3c49415f