### PR TITLE
Post regression diagram file to /render in preview workflow

### DIFF
--- a/.github/pr-images/pr-32/nagare-test.svg
+++ b/.github/pr-images/pr-32/nagare-test.svg
@@ -1,0 +1,113 @@
+<svg width="950" height="400" xmlns="http://www.w3.org/2000/svg">
+        <!-- Background -->
+        <rect width="950" height="400" fill="#ffffff"/>
+        
+        <g transform="translate(50.000000,100.000000)">
+                <g class="ns" filter="url(#softShadow)">
+                        <rect x="0" y="0" width="200.000000" height="150.000000" rx="3.125000" fill="#e6f3ff" stroke="#333"/>
+                        <rect x="0" y="0" width="200.000000" height="15.714285" rx="3.125000" ry="3.125000" fill="#e6f3ff" stroke="#333"/>
+                        <rect x="31.250000" y="3.571425" width="150.000000" height="8.571420" rx="1.875000" fill="#fff" stroke="#333" opacity="0.85"/>
+                        <rect x="3.750000" y="19.999995" width="192.500000" height="125.714280" rx="1.875000" fill="#ffffff" stroke="#333" opacity="0.9"/>
+                </g>
+                <text x="106.250000" y="7.857135" text-anchor="middle" dominant-baseline="middle"
+                        font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif"
+                        font-size="8.000000" fill="#333">https://www.nagare.com</text>
+                <text x="100.000000" y="82.857135" text-anchor="middle" dominant-baseline="middle"
+                        font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif"
+                        font-size="20" fill="#333">Home Page</text>
+                <g transform="translate(4.375000,4.999995)">
+                        <circle r="1.875000" cx="0" cy="2.493750" fill="#ff5f57"/>
+                        <circle r="1.875000" cx="5.625000" cy="2.493750" fill="#febc2e"/>
+                        <circle r="1.875000" cx="11.250000" cy="2.493750" fill="#28c840"/>
+                </g>
+        </g><g transform="translate(300.000000,25.000000)">
+                <g class="ns" filter="url(#softShadow)">
+                        <rect x="0" y="0" width="600.000000" height="300.000000" rx="9.375000" fill="#333" stroke="#ccc"/>
+                        <rect x="0" y="0" width="600.000000" height="31.428570" rx="9.375000" ry="9.375000" fill="#333" stroke="#ccc"/>
+                        <rect x="11.250000" y="39.999990" width="577.500000" height="251.428560" rx="5.625000" fill="#ccc" stroke="#ccc" opacity="0.9"/>
+                </g>
+                <g transform="translate(13.125000,9.999990)">
+                        <circle r="5.625000" cx="0" cy="7.481250" fill="#ff5f57"/>
+                        <circle r="5.625000" cx="16.875000" cy="7.481250" fill="#febc2e"/>
+                        <circle r="5.625000" cx="33.750000" cy="7.481250" fill="#28c840"/>
+                        <!-- Title text positioned after controls -->
+                        <text x="61.875000" 
+                              y="7.481250" 
+                              text-anchor="start" 
+                              dominant-baseline="middle"
+                              font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif"
+                              font-size="30" 
+                              fill="#ccc">home@ubuntu</text>
+                </g>
+        </g><g transform="translate(311.250000,64.999990)">
+<g transform="translate(50.000000,85.000010)">
+    <!-- Main server box -->
+    <rect x="0" y="0" width="200.000000" height="50.000000" 
+          rx="5.000000" ry="5.000000" 
+          fill="#e6f3ff" stroke="#333" stroke-width="2"/>
+    
+    <!-- Icon -->
+    
+    
+    <g transform="translate(7.500000,7.500000)">
+        
+        <!-- Nginx icon -->
+        <rect x="0" y="0" width="35.000000" height="35.000000" fill="#009639"/>
+        <text x="17.500000" y="24.500000" 
+              fill="#ffffff" font-family="Arial" font-size="21.000000" 
+              text-anchor="middle">N</text>
+        
+    </g>
+    
+    <!-- Title -->
+    <text x="57.500000" 
+          y="30.000000" 
+          fill="#333" 
+          font-family="Arial" 
+          font-size="20.000000"
+          >nginx</text>
+    
+    <!-- Port display -->
+    <text x="192.500000" 
+          y="30.000000" 
+          fill="#333" 
+          font-family="Arial" 
+          font-size="17.500000"
+          text-anchor="end">:80</text>
+</g>
+<g transform="translate(350.000000,85.000010)">
+    <!-- Main server box -->
+    <rect x="0" y="0" width="200.000000" height="50.000000" 
+          rx="5.000000" ry="5.000000" 
+          fill="#f0f8ff" stroke="#333" stroke-width="2"/>
+    
+    <!-- Icon -->
+    
+    
+    <g transform="translate(7.500000,7.500000)">
+        
+        <!-- Golang icon -->
+        <rect x="0" y="0" width="35.000000" height="35.000000" fill="#00ADD8"/>
+        <text x="17.500000" y="24.500000" 
+              fill="#ffffff" font-family="Arial" font-size="21.000000" 
+              text-anchor="middle">Go</text>
+        
+    </g>
+    
+    <!-- Title -->
+    <text x="57.500000" 
+          y="30.000000" 
+          fill="#333" 
+          font-family="Arial" 
+          font-size="20.000000"
+          >App</text>
+    
+    <!-- Port display -->
+    <text x="192.500000" 
+          y="30.000000" 
+          fill="#333" 
+          font-family="Arial" 
+          font-size="17.500000"
+          text-anchor="end">:8080</text>
+</g></g><g class="connector"><defs><marker id="arrowhead-1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/></marker></defs><polyline points="250.00,175.00 361.25,175.00" stroke="#1f2937" stroke-width="2.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead-1)"/></g><g class="connector"><defs><marker id="arrowhead-2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/></marker></defs><polyline points="561.25,175.00 661.25,175.00" stroke="#1f2937" stroke-width="2.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead-2)"/></g>
+</svg>

--- a/.github/workflows/render-preview.yml
+++ b/.github/workflows/render-preview.yml
@@ -33,10 +33,14 @@ jobs:
           ./nagare-server > server.log 2>&1 &
           echo $! > server.pid
 
-      - name: Fetch /test SVG output
+      - name: Render regression diagram via /render
         run: |
           for attempt in {1..60}; do
-            if curl -fsS http://localhost:8080/test -o nagare-test.svg; then
+            if curl -fsS -X POST \
+              -H 'Content-Type: text/plain' \
+              --data-binary @pkg/testdiagram/test-diagram.nagare \
+              http://localhost:8080/render \
+              -o nagare-test.svg; then
               exit 0
             fi
             sleep 1

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ nagare
 
 ## Examples
 
-Pull requests automatically run a preview workflow that boots the Nagare server, renders the `/test` diagram, and attaches the resulting SVG to the PR discussion for quick review.
+Pull requests automatically run a preview workflow that boots the Nagare server, posts the contents of [`pkg/testdiagram/test-diagram.nagare`](pkg/testdiagram/test-diagram.nagare) to the `/render` endpoint, and attaches the resulting SVG to the PR discussion for quick review.
 
 ## Layout Overrides
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,8 +22,8 @@ func handleTest(w http.ResponseWriter, r *http.Request) {
 
 browser:Browser@home
 vps:VM@ubuntu {
-    nginx:Server@nginx
-    app:Server@app
+nginx:Server@nginx
+app:Server@app
 }
 
 browser.e --> nginx.w

--- a/pkg/testdiagram/test-diagram.nagare
+++ b/pkg/testdiagram/test-diagram.nagare
@@ -1,0 +1,19 @@
+@layout(w:950,h:400)
+
+browser:Browser@home
+vps:VM@ubuntu {
+    nginx:Server@nginx
+    app:Server@app
+}
+
+browser.e --> nginx.w
+nginx.e --> app.w
+
+@browser(x:50,y:100,w:200,h:150)
+@home(url: "https://www.nagare.com", bg: "#e6f3ff", fg: "#333", text: "Home Page")
+
+@vps(x:300,y:&browser.c,w:600,h:300)
+@ubuntu(title: "home@ubuntu", bg: "#333", fg: "#ccc", text: "Ubuntu")
+
+@nginx(x:50,y:&browser.c,w:200,h:50, title: "nginx", icon: "nginx", port: 80, bg: "#e6f3ff", fg: "#333")
+@app(x:350,y:&browser.c,w:200,h:50, title: "App", icon: "golang", port: 8080, bg: "#f0f8ff", fg: "#333")

--- a/pkg/testdiagram/testdiagram.go
+++ b/pkg/testdiagram/testdiagram.go
@@ -1,0 +1,8 @@
+package testdiagram
+
+import _ "embed"
+
+// Diagram is the default diagram used for regression previews.
+//
+//go:embed test-diagram.nagare
+var Diagram string


### PR DESCRIPTION
## Summary
- restore the /test handler to keep its embedded regression example for quick manual checks
- update the preview workflow to post pkg/testdiagram/test-diagram.nagare to /render so automation matches manual output

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de2236e130832883361412cacd6e75