### PR TITLE
Render all test diagrams in preview workflow

### DIFF
--- a/.github/testdiagrams/test-diagram.nagare
+++ b/.github/testdiagrams/test-diagram.nagare
@@ -1,0 +1,19 @@
+@layout(w:950,h:400)
+
+browser:Browser@home
+vps:VM@ubuntu {
+    nginx:Server@nginx
+    app:Server@app
+}
+
+browser.e --> nginx.w
+nginx.e --> app.w
+
+@browser(x:50,y:100,w:200,h:150)
+@home(url: "https://www.nagare.com", bg: "#e6f3ff", fg: "#333", text: "Home Page")
+
+@vps(x:300,y:&browser.c,w:600,h:300)
+@ubuntu(title: "home@ubuntu", bg: "#333", fg: "#ccc", text: "Ubuntu")
+
+@nginx(x:50,y:&browser.c,w:200,h:50, title: "nginx", icon: "nginx", port: 80, bg: "#e6f3ff", fg: "#333")
+@app(x:350,y:&browser.c,w:200,h:50, title: "App", icon: "golang", port: 8080, bg: "#f0f8ff", fg: "#333")

--- a/.github/workflows/render-preview.yml
+++ b/.github/workflows/render-preview.yml
@@ -33,16 +33,38 @@ jobs:
           ./nagare-server > server.log 2>&1 &
           echo $! > server.pid
 
-      - name: Fetch /test SVG output
+      - name: Render regression diagrams via /render
         run: |
+          set -euo pipefail
+
+          shopt -s nullglob
+          diagrams=(.github/testdiagrams/*.nagare)
+          if [ ${#diagrams[@]} -eq 0 ]; then
+            echo "No .nagare files found in .github/testdiagrams" >&2
+            exit 1
+          fi
+
+          # Wait for the server to be ready.
           for attempt in {1..60}; do
-            if curl -fsS http://localhost:8080/test -o nagare-test.svg; then
-              exit 0
+            if curl -fsS http://localhost:8080/test >/dev/null 2>&1; then
+              break
+            fi
+            if [ "$attempt" -eq 60 ]; then
+              echo "Server failed to respond" >&2
+              exit 1
             fi
             sleep 1
           done
-          echo "Server failed to respond" >&2
-          exit 1
+
+          for nagare_file in "${diagrams[@]}"; do
+            base_name=$(basename "$nagare_file" .nagare)
+            echo "Rendering $nagare_file"
+            curl -fsS -X POST \
+              -H 'Content-Type: text/plain' \
+              --data-binary @"$nagare_file" \
+              http://localhost:8080/render \
+              -o "${base_name}.svg"
+          done
 
       - name: Stop Nagare server
         if: always()
@@ -110,21 +132,32 @@ jobs:
 
           COMMENT_BODY="## 🎨 Generated SVG Examples\n\n"
 
-          counter=1
-          for svg_file in .github/pr-images/pr-$PR_NUMBER/*.svg; do
-            if [ -f "$svg_file" ]; then
-              filename=$(basename "$svg_file")
-              display_name="${filename%.svg}"
-              raw_url="https://github.com/$REPO/blob/$CURRENT_SHA/.github/pr-images/pr-$PR_NUMBER/$filename?raw=1"
+          shopt -s nullglob
+          diagrams=(.github/testdiagrams/*.nagare)
+          if [ ${#diagrams[@]} -eq 0 ]; then
+            echo "No diagrams found to document" >&2
+            exit 0
+          fi
 
-              COMMENT_BODY+="### Example $counter: $display_name\n"
-              COMMENT_BODY+="![${display_name}](${raw_url})\n\n"
-              COMMENT_BODY+="<details><summary>View SVG source</summary>\n\n"
-              COMMENT_BODY+=$(printf '[`%s`](%s)\n\n' "$filename" "$raw_url")
-              COMMENT_BODY+="</details>\n\n"
+          for nagare_file in "${diagrams[@]}"; do
+            nagare_name=$(basename "$nagare_file")
+            base_name=${nagare_name%.nagare}
+            filename="${base_name}.svg"
+            svg_file=.github/pr-images/pr-$PR_NUMBER/$filename
 
-              counter=$((counter + 1))
+            if [ ! -f "$svg_file" ]; then
+              echo "Skipping $nagare_name because $svg_file is missing" >&2
+              continue
             fi
+
+            raw_url="https://github.com/$REPO/blob/$CURRENT_SHA/.github/pr-images/pr-$PR_NUMBER/$filename?raw=1"
+            nagare_url="https://github.com/$REPO/blob/$CURRENT_SHA/.github/testdiagrams/$nagare_name"
+
+            COMMENT_BODY+="### ${nagare_name}\n"
+            COMMENT_BODY+="![${nagare_name}](${raw_url})\n\n"
+            COMMENT_BODY+="<details><summary>View sources</summary>\n\n"
+            COMMENT_BODY+=$(printf '[`%s`](%s) · [`%s`](%s)\n\n' "$filename" "$raw_url" "$nagare_name" "$nagare_url")
+            COMMENT_BODY+="</details>\n\n"
           done
 
           COMMENT_BODY+="---\n"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ nagare
 
 ## Examples
 
-Pull requests automatically run a preview workflow that boots the Nagare server, renders the `/test` diagram, and attaches the resulting SVG to the PR discussion for quick review.
+Pull requests automatically run a preview workflow that boots the Nagare server, posts the contents of [`.github/testdiagrams/test-diagram.nagare`](.github/testdiagrams/test-diagram.nagare) to the `/render` endpoint, and attaches the resulting SVG to the PR discussion for quick review.
 
 ## Layout Overrides
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,8 +22,8 @@ func handleTest(w http.ResponseWriter, r *http.Request) {
 
 browser:Browser@home
 vps:VM@ubuntu {
-    nginx:Server@nginx
-    app:Server@app
+nginx:Server@nginx
+app:Server@app
 }
 
 browser.e --> nginx.w


### PR DESCRIPTION
## Summary
- move regression diagram DSL files into .github/testdiagrams for workflow-driven rendering
- update the preview workflow to render every .nagare file and attribute uploaded SVGs to their source filenames
- document the new diagram location in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de2236e130832883361412cacd6e75