### PR TITLE
Avoid rendering default server decorations on rectangles

### DIFF
--- a/.github/pr-images/pr-37/fn-cascade.svg
+++ b/.github/pr-images/pr-37/fn-cascade.svg
@@ -1,0 +1,41 @@
+<svg width="800" height="300" xmlns="http://www.w3.org/2000/svg">
+        <!-- Background -->
+        <rect width="800" height="300" fill="#ffffff"/>
+        
+        <g transform="translate(0.000000,0.000000)">
+    <rect x="0" y="0" width="300.000000" height="30.000000"
+          rx="3.000000" ry="3.000000"
+          fill="#e6f3ff" stroke="#333333" stroke-width="2"/>
+    <text x="150.000000" y="15.000000"
+          font-family="Arial" font-size="14" fill="#333333"
+          text-anchor="middle" dominant-baseline="middle">registerUser</text>
+</g><g transform="translate(100.000000,50.000000)">
+    <rect x="0" y="0" width="300.000000" height="30.000000"
+          rx="3.000000" ry="3.000000"
+          fill="#e6f3ff" stroke="#333333" stroke-width="2"/>
+    <text x="150.000000" y="15.000000"
+          font-family="Arial" font-size="14" fill="#333333"
+          text-anchor="middle" dominant-baseline="middle">validateUser</text>
+</g><g transform="translate(200.000000,100.000000)">
+    <rect x="0" y="0" width="300.000000" height="30.000000"
+          rx="3.000000" ry="3.000000"
+          fill="#e6f3ff" stroke="#333333" stroke-width="2"/>
+    <text x="150.000000" y="15.000000"
+          font-family="Arial" font-size="14" fill="#333333"
+          text-anchor="middle" dominant-baseline="middle">createUser</text>
+</g><g transform="translate(300.000000,150.000000)">
+    <rect x="0" y="0" width="300.000000" height="30.000000"
+          rx="3.000000" ry="3.000000"
+          fill="#e6f3ff" stroke="#333333" stroke-width="2"/>
+    <text x="150.000000" y="15.000000"
+          font-family="Arial" font-size="14" fill="#333333"
+          text-anchor="middle" dominant-baseline="middle">sendConfirmationEmail</text>
+</g><g transform="translate(400.000000,200.000000)">
+    <rect x="0" y="0" width="300.000000" height="30.000000"
+          rx="3.000000" ry="3.000000"
+          fill="#e6f3ff" stroke="#333333" stroke-width="2"/>
+    <text x="150.000000" y="15.000000"
+          font-family="Arial" font-size="14" fill="#333333"
+          text-anchor="middle" dominant-baseline="middle">logRegistration</text>
+</g><g class="connector"><defs><marker id="arrowhead-3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/></marker></defs><polyline points="75.00,30.00 51.00,30.00 51.00,65.00 100.00,65.00" stroke="#1f2937" stroke-width="2.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead-3)"/></g><g class="connector"><defs><marker id="arrowhead-4" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/></marker></defs><polyline points="175.00,80.00 151.00,80.00 151.00,115.00 200.00,115.00" stroke="#1f2937" stroke-width="2.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead-4)"/></g><g class="connector"><defs><marker id="arrowhead-5" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/></marker></defs><polyline points="275.00,130.00 251.00,130.00 251.00,165.00 300.00,165.00" stroke="#1f2937" stroke-width="2.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead-5)"/></g><g class="connector"><defs><marker id="arrowhead-6" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/></marker></defs><polyline points="375.00,180.00 351.00,180.00 351.00,215.00 400.00,215.00" stroke="#1f2937" stroke-width="2.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead-6)"/></g>
+</svg>

--- a/.github/pr-images/pr-37/test-diagram.svg
+++ b/.github/pr-images/pr-37/test-diagram.svg
@@ -1,0 +1,123 @@
+<svg width="950" height="400" xmlns="http://www.w3.org/2000/svg">
+        <!-- Background -->
+        <rect width="950" height="400" fill="#ffffff"/>
+        
+        <g transform="translate(50.000000,100.000000)">
+                <g class="ns" filter="url(#softShadow)">
+                        <rect x="0" y="0" width="200.000000" height="150.000000" rx="3.125000" fill="#e6f3ff" stroke="#333"/>
+                        <rect x="0" y="0" width="200.000000" height="15.714285" rx="3.125000" ry="3.125000" fill="#e6f3ff" stroke="#333"/>
+                        <rect x="31.250000" y="3.571425" width="150.000000" height="8.571420" rx="1.875000" fill="#fff" stroke="#333" opacity="0.85"/>
+                        <rect x="3.750000" y="19.999995" width="192.500000" height="125.714280" rx="1.875000" fill="#ffffff" stroke="#333" opacity="0.9"/>
+                </g>
+                <text x="106.250000" y="7.857135" text-anchor="middle" dominant-baseline="middle"
+                        font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif"
+                        font-size="8.000000" fill="#333">https://www.nagare.com</text>
+                <text x="100.000000" y="82.857135" text-anchor="middle" dominant-baseline="middle"
+                        font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif"
+                        font-size="20" fill="#333">Home Page</text>
+                <g transform="translate(4.375000,4.999995)">
+                        <circle r="1.875000" cx="0" cy="2.493750" fill="#ff5f57"/>
+                        <circle r="1.875000" cx="5.625000" cy="2.493750" fill="#febc2e"/>
+                        <circle r="1.875000" cx="11.250000" cy="2.493750" fill="#28c840"/>
+                </g>
+        </g><g transform="translate(300.000000,25.000000)">
+                <g class="ns" filter="url(#softShadow)">
+                        <rect x="0" y="0" width="600.000000" height="300.000000" rx="9.375000" fill="#333" stroke="#ccc"/>
+                        <rect x="0" y="0" width="600.000000" height="31.428570" rx="9.375000" ry="9.375000" fill="#333" stroke="#ccc"/>
+                        <rect x="11.250000" y="39.999990" width="577.500000" height="251.428560" rx="5.625000" fill="#ccc" stroke="#ccc" opacity="0.9"/>
+                </g>
+                <g transform="translate(13.125000,9.999990)">
+                        <circle r="5.625000" cx="0" cy="7.481250" fill="#ff5f57"/>
+                        <circle r="5.625000" cx="16.875000" cy="7.481250" fill="#febc2e"/>
+                        <circle r="5.625000" cx="33.750000" cy="7.481250" fill="#28c840"/>
+                        <!-- Title text positioned after controls -->
+                        <text x="61.875000" 
+                              y="7.481250" 
+                              text-anchor="start" 
+                              dominant-baseline="middle"
+                              font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif"
+                              font-size="30" 
+                              fill="#ccc">home@ubuntu</text>
+                </g>
+        </g><g transform="translate(311.250000,64.999990)">
+<g transform="translate(50.000000,85.000010)">
+    <!-- Main server box -->
+    <rect x="0" y="0" width="200.000000" height="50.000000"
+          rx="5.000000" ry="5.000000"
+          fill="#e6f3ff" stroke="#333" stroke-width="2"/>
+
+    
+    
+    
+    
+    
+    <g transform="translate(7.500000,7.500000)">
+        
+        <!-- Nginx icon -->
+        <rect x="0" y="0" width="35.000000" height="35.000000" fill="#009639"/>
+        <text x="17.500000" y="24.500000"
+              fill="#ffffff" font-family="Arial" font-size="21.000000"
+              text-anchor="middle">N</text>
+        
+    </g>
+    
+
+    <!-- Title -->
+    <text x="57.500000"
+          y="30.000000"
+          fill="#333"
+          font-family="Arial"
+          font-size="20.000000"
+          >nginx</text>
+
+    <!-- Port display -->
+    
+    <text x="192.500000"
+          y="30.000000"
+          fill="#333"
+          font-family="Arial"
+          font-size="17.500000"
+          text-anchor="end">:80</text>
+    
+</g>
+<g transform="translate(350.000000,85.000010)">
+    <!-- Main server box -->
+    <rect x="0" y="0" width="200.000000" height="50.000000"
+          rx="5.000000" ry="5.000000"
+          fill="#f0f8ff" stroke="#333" stroke-width="2"/>
+
+    
+    
+    
+    
+    
+    <g transform="translate(7.500000,7.500000)">
+        
+        <!-- Golang icon -->
+        <rect x="0" y="0" width="35.000000" height="35.000000" fill="#00ADD8"/>
+        <text x="17.500000" y="24.500000"
+              fill="#ffffff" font-family="Arial" font-size="21.000000"
+              text-anchor="middle">Go</text>
+        
+    </g>
+    
+
+    <!-- Title -->
+    <text x="57.500000"
+          y="30.000000"
+          fill="#333"
+          font-family="Arial"
+          font-size="20.000000"
+          >App</text>
+
+    <!-- Port display -->
+    
+    <text x="192.500000"
+          y="30.000000"
+          fill="#333"
+          font-family="Arial"
+          font-size="17.500000"
+          text-anchor="end">:8080</text>
+    
+</g></g><g class="connector"><defs><marker id="arrowhead-7" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/></marker></defs><polyline points="250.00,175.00 361.25,175.00" stroke="#1f2937" stroke-width="2.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead-7)"/></g><g class="connector"><defs><marker id="arrowhead-8" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/></marker></defs><polyline points="561.25,175.00 661.25,175.00" stroke="#1f2937" stroke-width="2.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead-8)"/></g>
+</svg>

--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -26,8 +26,8 @@ func (s *ServerProps) Parse(input string) error {
 func DefaultServerProps() ServerProps {
 	return ServerProps{
 		Title:           "",
-		Icon:            "default",
-		Port:            80,
+		Icon:            "",
+		Port:            0,
 		BackgroundColor: "#e6f3ff",
 		ForegroundColor: "#333333",
 	}
@@ -115,48 +115,53 @@ func (s *Server) Draw() string {
 const ServerTemplate = `
 <g transform="translate({{printf "%.6f" .X}},{{printf "%.6f" .Y}})">
     <!-- Main server box -->
-    <rect x="0" y="0" width="{{printf "%.6f" .Width}}" height="{{printf "%.6f" .Height}}" 
-          rx="{{printf "%.6f" (mul .Height 0.1)}}" ry="{{printf "%.6f" (mul .Height 0.1)}}" 
+    <rect x="0" y="0" width="{{printf "%.6f" .Width}}" height="{{printf "%.6f" .Height}}"
+          rx="{{printf "%.6f" (mul .Height 0.1)}}" ry="{{printf "%.6f" (mul .Height 0.1)}}"
           fill="{{.Props.BackgroundColor}}" stroke="{{.Props.ForegroundColor}}" stroke-width="2"/>
-    
-    <!-- Icon -->
-    {{$iconSize := mul .Height 0.7}}
+
     {{$iconMargin := mul .Height 0.15}}
+    {{$titleX := mul .Height 0.2}}
+    {{if ne .Props.Icon ""}}
+    {{$iconSize := mul .Height 0.7}}
+    {{$titleX = add (mul .Height 1.0) $iconMargin}}
     <g transform="translate({{printf "%.6f" $iconMargin}},{{printf "%.6f" $iconMargin}})">
         {{if eq .Props.Icon "nginx"}}
         <!-- Nginx icon -->
         <rect x="0" y="0" width="{{printf "%.6f" $iconSize}}" height="{{printf "%.6f" $iconSize}}" fill="#009639"/>
-        <text x="{{printf "%.6f" (mul $iconSize 0.5)}}" y="{{printf "%.6f" (mul $iconSize 0.7)}}" 
-              fill="#ffffff" font-family="Arial" font-size="{{printf "%.6f" (mul $iconSize 0.6)}}" 
+        <text x="{{printf "%.6f" (mul $iconSize 0.5)}}" y="{{printf "%.6f" (mul $iconSize 0.7)}}"
+              fill="#ffffff" font-family="Arial" font-size="{{printf "%.6f" (mul $iconSize 0.6)}}"
               text-anchor="middle">N</text>
         {{else if eq .Props.Icon "golang"}}
         <!-- Golang icon -->
         <rect x="0" y="0" width="{{printf "%.6f" $iconSize}}" height="{{printf "%.6f" $iconSize}}" fill="#00ADD8"/>
-        <text x="{{printf "%.6f" (mul $iconSize 0.5)}}" y="{{printf "%.6f" (mul $iconSize 0.7)}}" 
-              fill="#ffffff" font-family="Arial" font-size="{{printf "%.6f" (mul $iconSize 0.6)}}" 
+        <text x="{{printf "%.6f" (mul $iconSize 0.5)}}" y="{{printf "%.6f" (mul $iconSize 0.7)}}"
+              fill="#ffffff" font-family="Arial" font-size="{{printf "%.6f" (mul $iconSize 0.6)}}"
               text-anchor="middle">Go</text>
         {{else}}
         <!-- Default server icon -->
         <rect x="0" y="0" width="{{printf "%.6f" $iconSize}}" height="{{printf "%.6f" $iconSize}}" fill="#666666"/>
-        <text x="{{printf "%.6f" (mul $iconSize 0.5)}}" y="{{printf "%.6f" (mul $iconSize 0.7)}}" 
-              fill="#ffffff" font-family="Arial" font-size="{{printf "%.6f" (mul $iconSize 0.6)}}" 
+        <text x="{{printf "%.6f" (mul $iconSize 0.5)}}" y="{{printf "%.6f" (mul $iconSize 0.7)}}"
+              fill="#ffffff" font-family="Arial" font-size="{{printf "%.6f" (mul $iconSize 0.6)}}"
               text-anchor="middle">S</text>
         {{end}}
     </g>
-    
+    {{end}}
+
     <!-- Title -->
-    <text x="{{printf "%.6f" (add (mul .Height 1.0) $iconMargin)}}" 
-          y="{{printf "%.6f" (mul .Height 0.6)}}" 
-          fill="{{.Props.ForegroundColor}}" 
-          font-family="Arial" 
+    <text x="{{printf "%.6f" $titleX}}"
+          y="{{printf "%.6f" (mul .Height 0.6)}}"
+          fill="{{.Props.ForegroundColor}}"
+          font-family="Arial"
           font-size="{{printf "%.6f" (mul .Height 0.4)}}"
           >{{.Props.Title}}</text>
-    
+
     <!-- Port display -->
-    <text x="{{printf "%.6f" (sub .Width (mul .Height 0.15))}}" 
-          y="{{printf "%.6f" (mul .Height 0.6)}}" 
-          fill="{{.Props.ForegroundColor}}" 
-          font-family="Arial" 
+    {{if gt .Props.Port 0}}
+    <text x="{{printf "%.6f" (sub .Width (mul .Height 0.15))}}"
+          y="{{printf "%.6f" (mul .Height 0.6)}}"
+          fill="{{.Props.ForegroundColor}}"
+          font-family="Arial"
           font-size="{{printf "%.6f" (mul .Height 0.35)}}"
           text-anchor="end">:{{.Props.Port}}</text>
+    {{end}}
 </g>`

--- a/pkg/diagram/diagram_test.go
+++ b/pkg/diagram/diagram_test.go
@@ -2,6 +2,7 @@ package diagram
 
 import (
 	_ "embed"
+	"strings"
 	"testing"
 )
 
@@ -30,7 +31,7 @@ func TestCreateDiagramFromActualCodeBlocks(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if html != td.expected {
+			if strings.TrimSpace(html) != strings.TrimSpace(td.expected) {
 				t.Fatalf("expected HTML does not match actual.\nExpected:\n%s\n\nGot:\n%s", td.expected, html)
 			}
 		})

--- a/pkg/diagram/fixtures/svg_1.svg
+++ b/pkg/diagram/fixtures/svg_1.svg
@@ -42,107 +42,122 @@
         </g><g transform="translate(357.500000,36.666660)">
 <g transform="translate(20.000000,53.333340)">
     <!-- Main server box -->
-    <rect x="0" y="0" width="150.000000" height="40.000000" 
-          rx="4.000000" ry="4.000000" 
+    <rect x="0" y="0" width="150.000000" height="40.000000"
+          rx="4.000000" ry="4.000000"
           fill="#f0f8ff" stroke="#333" stroke-width="2"/>
+
     
-    <!-- Icon -->
+    
+    
     
     
     <g transform="translate(6.000000,6.000000)">
         
         <!-- Nginx icon -->
         <rect x="0" y="0" width="28.000000" height="28.000000" fill="#009639"/>
-        <text x="14.000000" y="19.600000" 
-              fill="#ffffff" font-family="Arial" font-size="16.800000" 
+        <text x="14.000000" y="19.600000"
+              fill="#ffffff" font-family="Arial" font-size="16.800000"
               text-anchor="middle">N</text>
         
     </g>
     
+
     <!-- Title -->
-    <text x="46.000000" 
-          y="24.000000" 
-          fill="#333" 
-          font-family="Arial" 
+    <text x="46.000000"
+          y="24.000000"
+          fill="#333"
+          font-family="Arial"
           font-size="16.000000"
           >nginx</text>
-    
+
     <!-- Port display -->
-    <text x="144.000000" 
-          y="24.000000" 
-          fill="#333" 
-          font-family="Arial" 
+    
+    <text x="144.000000"
+          y="24.000000"
+          fill="#333"
+          font-family="Arial"
           font-size="14.000000"
           text-anchor="end">:80</text>
+    
 </g>
 <g transform="translate(200.000000,53.333340)">
     <!-- Main server box -->
-    <rect x="0" y="0" width="150.000000" height="40.000000" 
-          rx="4.000000" ry="4.000000" 
+    <rect x="0" y="0" width="150.000000" height="40.000000"
+          rx="4.000000" ry="4.000000"
           fill="rgb(0, 119, 194)" stroke="#fff" stroke-width="2"/>
+
     
-    <!-- Icon -->
+    
+    
     
     
     <g transform="translate(6.000000,6.000000)">
         
         <!-- Golang icon -->
         <rect x="0" y="0" width="28.000000" height="28.000000" fill="#00ADD8"/>
-        <text x="14.000000" y="19.600000" 
-              fill="#ffffff" font-family="Arial" font-size="16.800000" 
+        <text x="14.000000" y="19.600000"
+              fill="#ffffff" font-family="Arial" font-size="16.800000"
               text-anchor="middle">Go</text>
         
     </g>
     
+
     <!-- Title -->
-    <text x="46.000000" 
-          y="24.000000" 
-          fill="#fff" 
-          font-family="Arial" 
+    <text x="46.000000"
+          y="24.000000"
+          fill="#fff"
+          font-family="Arial"
           font-size="16.000000"
           >blue</text>
-    
+
     <!-- Port display -->
-    <text x="144.000000" 
-          y="24.000000" 
-          fill="#fff" 
-          font-family="Arial" 
+    
+    <text x="144.000000"
+          y="24.000000"
+          fill="#fff"
+          font-family="Arial"
           font-size="14.000000"
           text-anchor="end">:8081</text>
+    
 </g>
 <g transform="translate(200.000000,110.000000)">
     <!-- Main server box -->
-    <rect x="0" y="0" width="150.000000" height="40.000000" 
-          rx="4.000000" ry="4.000000" 
+    <rect x="0" y="0" width="150.000000" height="40.000000"
+          rx="4.000000" ry="4.000000"
           fill="rgb(0, 118, 108)" stroke="#fff" stroke-width="2"/>
+
     
-    <!-- Icon -->
+    
+    
     
     
     <g transform="translate(6.000000,6.000000)">
         
         <!-- Golang icon -->
         <rect x="0" y="0" width="28.000000" height="28.000000" fill="#00ADD8"/>
-        <text x="14.000000" y="19.600000" 
-              fill="#ffffff" font-family="Arial" font-size="16.800000" 
+        <text x="14.000000" y="19.600000"
+              fill="#ffffff" font-family="Arial" font-size="16.800000"
               text-anchor="middle">Go</text>
         
     </g>
     
+
     <!-- Title -->
-    <text x="46.000000" 
-          y="24.000000" 
-          fill="#fff" 
-          font-family="Arial" 
+    <text x="46.000000"
+          y="24.000000"
+          fill="#fff"
+          font-family="Arial"
           font-size="16.000000"
           >green</text>
-    
+
     <!-- Port display -->
-    <text x="144.000000" 
-          y="24.000000" 
-          fill="#fff" 
-          font-family="Arial" 
+    
+    <text x="144.000000"
+          y="24.000000"
+          fill="#fff"
+          font-family="Arial"
           font-size="14.000000"
           text-anchor="end">:8082</text>
+    
 </g></g><g class="connector"><defs><marker id="arrowhead-1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/></marker></defs><polyline points="300.00,110.00 377.50,110.00" stroke="#1f2937" stroke-width="2.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead-1)"/></g><g class="connector"><defs><marker id="arrowhead-2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/></marker></defs><polyline points="527.50,110.00 557.50,110.00" stroke="#1f2937" stroke-width="2.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead-2)"/></g>
 </svg>


### PR DESCRIPTION
## Summary
- stop providing a default icon and port on servers so rectangle fallbacks no longer inherit them
- update the server SVG template to skip the icon and port sections unless explicitly configured
- trim whitespace in the diagram test comparison and refresh the embedded SVG snapshot to match the new rendering

## Testing
- go test ./pkg/diagram -run TestCreateDiagramFromActualCodeBlocks -count=1
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de9803fb148328b57b2e123b688cc9